### PR TITLE
color and sort lobby groups according to potency (fix #1)

### DIFF
--- a/src/components/Connections/index.js
+++ b/src/components/Connections/index.js
@@ -230,7 +230,12 @@ class Connections extends Component {
                         !isVisible && style.hidden
                       ].filter(Boolean).join(' ')}
                       onClick={toggle}
-                      style={{cursor: 'pointer'}}>
+                      style={{
+                        cursor: 'pointer',
+                        backgroundColor: !indirect
+                          ? POTENCY_COLORS[data.potency]
+                          : undefined
+                      }}>
                       <span className={indirect ? style.countVia : style.count}>{data.count}</span> {data.label}
                     </span>
                   )
@@ -353,6 +358,14 @@ export const hoverValues = [
   ]
 ]
 
+const POTENCY_WEIGHT = {
+  HIGH: 1000,
+  MEDIUM: 50,
+  LOW: 1
+}
+
+export const connectionWeight = connection => POTENCY_WEIGHT[connection.potency] || 1
+
 Connections.propTypes = {
   directness: PropTypes.number.isRequired,
   groupByDestination: PropTypes.bool.isRequired,
@@ -368,7 +381,7 @@ Connections.defaultProps = {
   intermediates: [],
   groupByDestination: false,
   maxGroups: undefined,
-  connectionWeight: () => 1,
+  connectionWeight: connectionWeight,
   hoverValues
 }
 

--- a/src/components/Connections/nest.js
+++ b/src/components/Connections/nest.js
@@ -1,6 +1,6 @@
 import {nest} from 'd3-collection'
 import {stratify} from 'd3-hierarchy'
-import {descending, ascending} from 'd3-array'
+import {descending, ascending, sum} from 'd3-array'
 
 const groupConnections = (connections, directness) => {
   const groups = nest()
@@ -50,8 +50,8 @@ export default ({
           b.key
         ))
         .sort((a, b) => descending(
-          a.values.map(connectionWeight),
-          b.values.map(connectionWeight)
+          sum(a.values.map(connectionWeight)),
+          sum(b.values.map(connectionWeight))
         ))
 
       const more = viaLevel.values.find(group => group.key === moreKey) || {
@@ -66,6 +66,10 @@ export default ({
           (rest, {values}) => rest.concat(values),
           []
         ))
+        more.values.sort((a, b) => descending(
+          connectionWeight(a),
+          connectionWeight(b)
+        ))
       }
       if (more.values.length) {
         visibleGroups.push(more)
@@ -78,6 +82,7 @@ export default ({
             id: `Group-${groupId}`,
             parentId: viaLevel.key || 'Root',
             type: 'Group',
+            potency: values.map(v => v.potency)[0],
             count: values.length,
             label: group
           }).concat(values.map((connection, i) => ({


### PR DESCRIPTION
This colors the lobby groups according to the highest potency on the detail page of a parliamentarian or guest. It also reorders the lobby groups by potency, see the Thomas Hardegger example.

As suggested by @scito in https://github.com/lobbywatch/website/issues/1

## Example Fabio Abate

Before
[![before-a](https://user-images.githubusercontent.com/410211/28754936-16d455d4-7550-11e7-9e38-ff217e41739c.png)](https://lobbywatch.ch/de/daten/parlamentarier/214/Fabio%20Abate)

After
[![after-a](https://user-images.githubusercontent.com/410211/28754941-3853acb4-7550-11e7-9ee2-158f3ee13115.png)](https://next.lobbywatch.ch/de/daten/parlamentarier/214/Fabio%20Abate)

## Example Thomas Hardegger

Before
[![before-h](https://user-images.githubusercontent.com/410211/28754949-4bc646a8-7550-11e7-828c-d1e139aa2fe8.png)](https://lobbywatch.ch/de/daten/parlamentarier/113/Thomas%20Hardegger)

After
[![after-h](https://user-images.githubusercontent.com/410211/28754951-55487494-7550-11e7-9345-557ba5a23a35.png)](https://next.lobbywatch.ch/de/daten/parlamentarier/113/Thomas%20Hardegger)

You can find this new version on [next.lobbywatch.ch](https://next.lobbywatch.ch), and compare it to before on [lobbywatch.ch](https://lobbywatch.ch).