### PR TITLE
group parliamentarians by canton

### DIFF
--- a/pages/parliamentarians.js
+++ b/pages/parliamentarians.js
@@ -4,7 +4,10 @@ import {graphql} from 'react-apollo'
 import gql from 'graphql-tag'
 import {withRouter} from 'next/router'
 
-import {H1, TextCenter} from '../src/components/Styled'
+import {nest} from 'd3-collection'
+import {ascending} from 'd3-array'
+
+import {H1, H2, TextCenter} from '../src/components/Styled'
 import Message from '../src/components/Message'
 
 import Loader from '../src/components/Loader'
@@ -43,7 +46,18 @@ const Parliamentarians = ({loading, error, parliamentarians, locale}) => (
       <TextCenter>
         <H1><Message id='menu/parliamentarians' locale={locale} /></H1>
       </TextCenter>
-      <ListView locale={locale} items={parliamentarians} />
+      {nest()
+        .key(item => item.canton)
+        .sortKeys(ascending)
+        .entries(parliamentarians)
+        .map(({key, values}) => (
+          <div key={key} style={{marginBottom: 50}}>
+            <H2>{key}</H2>
+            <ListView
+              locale={locale}
+              items={values} />
+          </div>
+        ))}
       <BlockRegion locale={locale}
         region='rooster_parliamentarians'
         style={{paddingTop: 50}} />

--- a/pages/parliamentarians.js
+++ b/pages/parliamentarians.js
@@ -55,7 +55,11 @@ const Parliamentarians = ({loading, error, parliamentarians, locale}) => (
             <H2>{key}</H2>
             <ListView
               locale={locale}
-              items={values} />
+              items={values}
+              subtitle={item => [
+                item.councilTitle,
+                item.partyMembership && item.partyMembership.party.abbr
+              ].filter(Boolean).join(', ')} />
           </div>
         ))}
       <BlockRegion locale={locale}

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -124,7 +124,8 @@ ListView.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({
     __typename: PropTypes.string.isRequired,
     id: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired
+    name: PropTypes.string.isRequired,
+    portrait: PropTypes.string
   })).isRequired,
   title: PropTypes.func.isRequired,
   subtitle: PropTypes.func.isRequired


### PR DESCRIPTION
As discussed in the last Vorstandssitzung: Roland and I implemented the grouped list for parliamentarians.

Desktop:
<img width="795" alt="Screenshot 2019-06-26 at 19 03 26" src="https://user-images.githubusercontent.com/410211/60199866-23a9b280-9845-11e9-891b-1e2e194adca6.png">

Mobile:
<img width="361" alt="Screenshot 2019-06-26 at 19 04 05" src="https://user-images.githubusercontent.com/410211/60199895-3623ec00-9845-11e9-8add-595cb4a5964b.png">
