### PR TITLE
Improve newsletter inscription behaviour in case of 'Content Blocking'

### DIFF
--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-07-24T06:49:48.337Z",
+  "updated": "2019-07-24T16:30:33.111Z",
   "title": "translations",
   "data": [
     {
@@ -224,8 +224,8 @@
     },
     {
       "key": "newsletter/error/timeout",
-      "de": "Verbindung zu MailChimp fehlgeschlagen, versuchen Sie es später nochmals.\nUrsache könnte auch ein 'Content Blocking' durch den Browser sein, z.B. Firefox Content Blocking 'Strict'. Schalten Sie das 'Content Blocking' während der Newsletter-Anmeldung temporär aus.",
-      "fr": "Erreurs dans la connexion avec MailChimp, réessayez plus tard.\nUne raison pourrait être le 'Content Blocking' du browser, par exemple 'Content Blocking Strict' de Firefox. Veuillez éteindre le 'Content Blocking' temporairement pendant l'inscription."
+      "de": "Verbindung zu MailChimp fehlgeschlagen, versuchen Sie es später nochmals.\nUrsache könnte auch ein «Content Blocking» durch den Browser sein, z.B. «Firefox Content Blocking ‹Strict›». Schalten Sie das «Content Blocking» während der Newsletter-Anmeldung temporär aus.",
+      "fr": "Erreurs dans la connexion avec MailChimp, réessayez plus tard.\nUne raison pourrait être le «Content Blocking» du browser, par exemple «Content Blocking Strict» de Firefox. Veuillez éteindre le «Content Blocking» temporairement pendant l'inscription."
     },
     {
       "key": "newsletter/error/generic",

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-03-24T12:43:23.568Z",
+  "updated": "2019-07-24T06:49:48.337Z",
   "title": "translations",
   "data": [
     {
@@ -213,14 +213,19 @@
       "fr": "S'inscrire"
     },
     {
+      "key": "newsletter/processing",
+      "de": "Anmelden…",
+      "fr": "Inscrire…"
+    },
+    {
       "key": "newsletter/succes",
       "de": "Abonnement erfolgreich.",
       "fr": "Inscription réussie"
     },
     {
       "key": "newsletter/error/timeout",
-      "de": "Verbindung zu MailChimp fehlgeschlagen, versuchen Sie es später nochmals.",
-      "fr": "Erreurs dans la connexion avec MailChimp, réessayez plus tard."
+      "de": "Verbindung zu MailChimp fehlgeschlagen, versuchen Sie es später nochmals.\nUrsache könnte auch ein 'Content Blocking' durch den Browser sein, z.B. Firefox Content Blocking 'Strict'. Schalten Sie das 'Content Blocking' während der Newsletter-Anmeldung temporär aus.",
+      "fr": "Erreurs dans la connexion avec MailChimp, réessayez plus tard.\nUne raison pourrait être le 'Content Blocking' du browser, par exemple 'Content Blocking Strict' de Firefox. Veuillez éteindre le 'Content Blocking' temporairement pendant l'inscription."
     },
     {
       "key": "newsletter/error/generic",

--- a/src/components/Frame/Newsletter.js
+++ b/src/components/Frame/Newsletter.js
@@ -51,7 +51,8 @@ class Newsletter extends Component {
       id: MAILCHIMP_ID_FOR_LOCALE[locale],
       hl: 'de'
     }
-    jsonp(`${MAILCHIMP_BASE_URL}/subscribe/post-json?${qs.encode(query)}`, {param: 'c'}, (error, data) => {
+    this.setState({message: t('newsletter/processing')})
+    jsonp(`${MAILCHIMP_BASE_URL}/subscribe/post-json?${qs.encode(query)}`, {param: 'c', timeout: 20000}, (error, data) => {
       if (error) {
         this.setState({message: t('newsletter/error/timeout')})
         return


### PR DESCRIPTION
Browsers like Firefox allow to 'Content Blocking'. Remote calls are not possible anymore in 'Strict' mode due to detected "Tracking behavior".

- Enhance error message about 'Content Blocking'
- Show a processing state before doing the remote call to show that something is going on (and keep people waiting for the timeout error message)
- Reduce timeout to 20s in order to avoid people leave before seeing the timeout error message (20s should be long enough)