### PR TITLE
Fix wrong condition for active parlamentarian, bis > now() means also…

### DIFF
--- a/graphql/mappers.js
+++ b/graphql/mappers.js
@@ -330,7 +330,7 @@ const mapParliamentarian = exports.mapParliamentarian = (raw, t) => {
       }
     } : null,
     canton: raw.kanton_name,
-    active: raw.aktiv,
+    active: !!+raw.aktiv,
     council: raw.ratstyp,
     councilTitle: () => {
       return t(

--- a/graphql/mappers.js
+++ b/graphql/mappers.js
@@ -330,7 +330,7 @@ const mapParliamentarian = exports.mapParliamentarian = (raw, t) => {
       }
     } : null,
     canton: raw.kanton_name,
-    active: !councilExitDate,
+    active: raw.aktiv,
     council: raw.ratstyp,
     councilTitle: () => {
       return t(


### PR DESCRIPTION
… active. Solution: Use aktiv field from the interface.