### PR TITLE
Show last 3 compensations

### DIFF
--- a/graphql/mappers.js
+++ b/graphql/mappers.js
@@ -243,6 +243,11 @@ const mapMandate = (origin, connection, t) => ({
   group: connection.interessengruppe,
   potency: connection.wirksamkeit_index && potencyMap[connection.wirksamkeit_index],
   function: () => mapFunction(t, Object.assign({gender: origin.gender}, connection)),
+  compensations: (connection.verguetungen_pro_jahr || []).map((raw) => ({
+    year: raw.jahr && +raw.jahr,
+    money: +raw.verguetung || null,
+    description: raw.beschreibung || null
+  })).sort((a, b) => b.year - a.year),
   compensation: connection.verguetung !== null ? ({
     year: connection.verguetung_jahr && +connection.verguetung_jahr,
     money: +connection.verguetung,

--- a/graphql/mappers.js
+++ b/graphql/mappers.js
@@ -33,6 +33,12 @@ const mapFunction = (t, {beschreibung, art, funktion_im_gremium: funktion, recht
   return translated
 }
 
+const mapCompensations = (t, verguetungen_pro_jahr) => (verguetungen_pro_jahr || []).map((raw) => ({
+          year: raw.jahr && +raw.jahr,
+          money: raw.verguetung !== undefined && raw.verguetung !== null ? +raw.verguetung : null,
+          description: raw.beschreibung || null
+        })).sort((a, b) => b.year - a.year)
+
 const lobbyGroupIdPrefix = exports.lobbyGroupIdPrefix = 'LobbyGroup-'
 exports.mapLobbyGroup = (raw, t) => {
   const connections = () => {
@@ -170,6 +176,7 @@ const mapOrganisation = exports.mapOrganisation = (raw, t) => {
         group: parliamentarian.partyMembership
           ? parliamentarian.partyMembership.party.abbr
           : t('connections/party/none'),
+        compensations: mapCompensations(t, directConnection.verguetungen_pro_jahr),
         function: mapFunction(t, Object.assign({}, directConnection, {
           gender: parliamentarian.gender,
           rechtsform: org.legalFormId
@@ -243,11 +250,7 @@ const mapMandate = (origin, connection, t) => ({
   group: connection.interessengruppe,
   potency: connection.wirksamkeit_index && potencyMap[connection.wirksamkeit_index],
   function: () => mapFunction(t, Object.assign({gender: origin.gender}, connection)),
-  compensations: (connection.verguetungen_pro_jahr || []).map((raw) => ({
-    year: raw.jahr && +raw.jahr,
-    money: +raw.verguetung || null,
-    description: raw.beschreibung || null
-  })).sort((a, b) => b.year - a.year),
+  compensations: mapCompensations(t, connection.verguetungen_pro_jahr),
   compensation: connection.verguetung !== null ? ({
     year: connection.verguetung_jahr && +connection.verguetung_jahr,
     money: +connection.verguetung,

--- a/graphql/mappers.js
+++ b/graphql/mappers.js
@@ -33,7 +33,7 @@ const mapFunction = (t, {beschreibung, art, funktion_im_gremium: funktion, recht
   return translated
 }
 
-const mapCompensations = (t, verguetungen_pro_jahr) => (verguetungen_pro_jahr || []).map((raw) => ({
+const mapCompensations = verguetungen_pro_jahr => (verguetungen_pro_jahr || []).map((raw) => ({
           year: raw.jahr && +raw.jahr,
           money: raw.verguetung !== undefined && raw.verguetung !== null ? +raw.verguetung : null,
           description: raw.beschreibung || null
@@ -176,7 +176,7 @@ const mapOrganisation = exports.mapOrganisation = (raw, t) => {
         group: parliamentarian.partyMembership
           ? parliamentarian.partyMembership.party.abbr
           : t('connections/party/none'),
-        compensations: mapCompensations(t, directConnection.verguetungen_pro_jahr),
+        compensations: mapCompensations(directConnection.verguetungen_pro_jahr),
         function: mapFunction(t, Object.assign({}, directConnection, {
           gender: parliamentarian.gender,
           rechtsform: org.legalFormId
@@ -250,7 +250,7 @@ const mapMandate = (origin, connection, t) => ({
   group: connection.interessengruppe,
   potency: connection.wirksamkeit_index && potencyMap[connection.wirksamkeit_index],
   function: () => mapFunction(t, Object.assign({gender: origin.gender}, connection)),
-  compensations: mapCompensations(t, connection.verguetungen_pro_jahr),
+  compensations: mapCompensations(connection.verguetungen_pro_jahr),
   compensation: connection.verguetung !== null ? ({
     year: connection.verguetung_jahr && +connection.verguetung_jahr,
     money: +connection.verguetung,

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -150,8 +150,10 @@ type Connection {
   from: Entity!
   to: Entity!
   vias: [Connection!]!
+  # Last available compensation
   compensation: Compensation
-  compensations: [Compensation!]!
+  # Yearly compensations
+  compensations: [Compensation!]
   group: String
   potency: Potency
   function: String

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -91,7 +91,7 @@ type Commission {
 }
 
 type Compensation {
-  year: Int
+  year: Int!
   # measured in yearly CHF
   money: Int
   description: String
@@ -151,6 +151,7 @@ type Connection {
   to: Entity!
   vias: [Connection!]!
   compensation: Compensation
+  compensations: [Compensation!]!
   group: String
   potency: Potency
   function: String

--- a/lib/translations.json
+++ b/lib/translations.json
@@ -1,5 +1,5 @@
 {
-  "updated": "2019-07-24T16:30:33.111Z",
+  "updated": "2019-09-14T07:49:17.995Z",
   "title": "translations",
   "data": [
     {
@@ -21,6 +21,11 @@
       "key": "menu/lobbygroups",
       "de": "Lobbygruppen",
       "fr": "Groupes d'intérêt"
+    },
+    {
+      "key": "menu/branchs",
+      "de": "Branchen",
+      "fr": "Branches"
     },
     {
       "key": "menu/guests",
@@ -115,7 +120,17 @@
     {
       "key": "lobbygroup/meta/description/other",
       "de": "Die Lobbygruppe {name} ({sector}) hat {count} Verbindungen ({partyCounts}) ins Parlament.",
-      "fr": "Le lobby {name} ({sector}) a {count} relations ({partyCounts})au parlement."
+      "fr": "Le lobby {name} ({sector}) a {count} relations ({partyCounts}) au parlement."
+    },
+    {
+      "key": "branchs/meta/description",
+      "de": "{count} Branchen nehmen Einfluss auf die Politik in der Schweiz.",
+      "fr": "{count} branches influencent la politique en Suisse"
+    },
+    {
+      "key": "branch/meta/description",
+      "de": "Die Branche {name} der Schweizer Wirtschaft.",
+      "fr": "La branche {name} de l'économie suisse."
     },
     {
       "key": "organisation/meta/description/0",
@@ -395,6 +410,11 @@
       "fr": "Groupe d'intérêt non trouvé"
     },
     {
+      "key": "branch/error/404",
+      "de": "Branche nicht gefunden",
+      "fr": "Branche non trouvé"
+    },
+    {
       "key": "connections/legend/type/title",
       "de": "Verbindungsart",
       "fr": "Lien"
@@ -450,6 +470,11 @@
       "fr": "Branche"
     },
     {
+      "key": "connections/context/branch",
+      "de": "Branche",
+      "fr": "Branche"
+    },
+    {
       "key": "connections/context/lobbygroup",
       "de": "Lobbygruppe",
       "fr": "Groupe d'intérêt"
@@ -461,8 +486,8 @@
     },
     {
       "key": "connections/context/compensation",
-      "de": "Entschädigung",
-      "fr": "Indemnité"
+      "de": "Entschädigungen pro Jahr",
+      "fr": "Indemnités par année"
     },
     {
       "key": "connections/context/compensation/periode",
@@ -471,7 +496,7 @@
     },
     {
       "key": "connections/context/compensation/notAvailable",
-      "de": "Keine Angabe",
+      "de": "keine Angabe",
       "fr": "pas d'information"
     },
     {
@@ -493,6 +518,11 @@
       "key": "connections/organisation",
       "de": "Organisationen",
       "fr": "Organisations"
+    },
+    {
+      "key": "connections/lobbyGroup",
+      "de": "Lobbygruppen",
+      "fr": "Groupes d'intérêt"
     },
     {
       "key": "connections/groups/arbeitet fuer",

--- a/pages/guest.js
+++ b/pages/guest.js
@@ -31,7 +31,8 @@ const guestQuery = gql`
         group
         potency
         function
-        compensation {
+        compensations {
+          year
           money
           description
         }

--- a/pages/organisation.js
+++ b/pages/organisation.js
@@ -33,7 +33,8 @@ const orgQuery = gql`
         group
         potency
         function
-        compensation {
+        compensations {
+          year
           money
           description
         }

--- a/pages/parliamentarian.js
+++ b/pages/parliamentarian.js
@@ -53,7 +53,8 @@ const parliamentarianQuery = gql`
         group
         potency
         function
-        compensation {
+        compensations {
+          year
           money
           description
         }

--- a/src/components/Connections/index.js
+++ b/src/components/Connections/index.js
@@ -354,10 +354,10 @@ export const hoverValues = [
   [
     'connections/context/compensation',
     ({data: {connection, connection: {compensations}}}) => (
-      !!compensations ||
+      !!compensations && compensations.length > 0 ||
       (
-        (connection.from && connection.from.__typename === 'Parliamentarian' ||
-        connection.to && connection.to.__typename === 'Parliamentarian') &&
+        connection.from &&
+        connection.from.__typename === 'Parliamentarian' &&
         !connection.vias.length
       )
     ),

--- a/src/components/Connections/index.js
+++ b/src/components/Connections/index.js
@@ -361,15 +361,15 @@ export const hoverValues = [
         !connection.vias.length
       )
     ),
-    ({data: {connection: {compensation}}}, {t}) => compensation
-      ? (
-        <span>
-          {chfFormat(compensation.money)}
-          {' '}{t('connections/context/compensation/periode')}
-          {!!compensation.description && ` (${compensation.description})`}
-        </span>
-      )
-      : t('connections/context/compensation/notAvailable')
+    ({data: {connection: {compensations}}}, {t}) => compensations.filter((e, i) => i < 3).map(compensation =>
+      <div>
+        {compensation.year}{': '}
+        {compensation.money !== null ?
+          chfFormat(compensation.money) +
+          (compensation.description ? ` (${compensation.description})` : '')
+        : t('connections/context/compensation/notAvailable')}
+      </div>
+    )
   ],
   [
     null,

--- a/src/components/Connections/index.js
+++ b/src/components/Connections/index.js
@@ -353,16 +353,16 @@ export const hoverValues = [
   ['connections/context/function', ({data}) => data.connection['function']],
   [
     'connections/context/compensation',
-    ({data: {connection, connection: {compensation}}}) => (
-      !!compensation ||
+    ({data: {connection, connection: {compensations}}}) => (
+      !!compensations ||
       (
-        connection.from &&
-        connection.from.__typename === 'Parliamentarian' &&
+        (connection.from && connection.from.__typename === 'Parliamentarian' ||
+        connection.to && connection.to.__typename === 'Parliamentarian') &&
         !connection.vias.length
       )
     ),
-    ({data: {connection: {compensations}}}, {t}) => compensations.filter((e, i) => i < 3).map(compensation =>
-      <div>
+    ({data: {connection: {compensations}}}, {t}) => compensations.filter((e, i) => i < 3).map((compensation, i) =>
+      <div key={`compensation-${i}`}>
         {compensation.year}{': '}
         {compensation.money !== null ?
           chfFormat(compensation.money) +

--- a/src/components/DetailHead.js
+++ b/src/components/DetailHead.js
@@ -119,6 +119,7 @@ DetailHead.defaultProps = {
           d.canton
         ].filter(Boolean).join(', ')
       case 'Guest':
+        const rawParlamentarianId = d.parliamentarian.id.replace(`${d.parliamentarian.__typename}-`, '')
         return (<span>
           {
             intersperse([
@@ -126,7 +127,7 @@ DetailHead.defaultProps = {
               <span key='invited'>
                 {t(`guest/${d.gender}/invited`)}
                 {' '}
-                <RouteLink route='parliamentarian' params={{locale, id: d.parliamentarian.id, name: d.parliamentarian.name}}>
+                <RouteLink route='parliamentarian' params={{locale, id: rawParlamentarianId, name: d.parliamentarian.name}}>
                   {d.parliamentarian.name}
                 </RouteLink>
               </span>


### PR DESCRIPTION
Implemented for parliamentarians, guests and organisations.

![image](https://user-images.githubusercontent.com/876593/64908655-79368280-d703-11e9-9474-d902d721bd3c.png)

It was not shown for organisations before.

![image](https://user-images.githubusercontent.com/876593/64908672-a2571300-d703-11e9-888e-4868218f409c.png)

I've fixed another bug: the link from the guest to the parliamentarian was not a raw id, but one with typename, see https://lobbywatch.ch/de/daten/zutrittsberechtigter/721/Manuela%20Rihm

I've kept the old compensation as it might be useful in showing the last known value.