### PR TITLE
Metadata improvements (fixes #49 #39 #27 #23 #22 #4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Lobbywatch Rooster
-
-> 2017 is the year of the Rooster, starting from January 28th, and ending on February 15th, 2018.
+# Lobbywatch Frontend
 
 Lobbywatch.ch build with React.js and the [Next.js](https://github.com/zeit/next.js/) Framework.
 
@@ -15,6 +13,13 @@ Run the following commands to start a local development server:
 ```bash
 npm install
 npm run dev
+```
+
+or with env settings
+
+```bash
+npm install
+PUBLIC_BASE_URL='http://lobbywatch.local' DEBUG_INFORMATION=1 npm run dev
 ```
 
 ## Deploy

--- a/graphql/mappers.js
+++ b/graphql/mappers.js
@@ -509,6 +509,9 @@ exports.mapPage = (locale, raw, statusCode) => {
     author: raw.type === 'article'
       ? raw.field_author
       : null,
+    authorUid: raw.type === 'article'
+      ? raw.field_author_uid
+      : null,
     published: raw.type === 'article' && raw.created
       ? formatTime(+raw.created * 1000)
       : null,

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -39,6 +39,7 @@ type Page {
   title: String
   image: String
   author: String
+  authorUid: Int
   content: String
   lead: String!
   type: String!

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -32,6 +32,7 @@ type PageTranslations {
   path: [String!]!
 }
 type Page {
+  nid: ID!
   statusCode: Int
   path: [String!]!
   translations: [PageTranslations!]!
@@ -40,8 +41,13 @@ type Page {
   author: String
   content: String
   lead: String!
+  type: String!
   # DD.MM.YYYY HH:MM
-  created: String
+  published: String
+  updated: String
+  # YYYY-MM-DD
+  publishedIso: String
+  updatedIso: String
   categories: [String!]
   tags: [String!]
   lobbyGroups: [String!]
@@ -67,11 +73,23 @@ interface Person {
   gender: Gender
   # Format: DD.MM.YYYY
   dateOfBirth: String
+  website: String
+  wikipedia_url: String
+  wikidata_url: String
+  twitter_name: String
+  twitter_url: String
+  linkedin_url: String
+  facebook_name: String
+  facebook_url: String
 }
 
 type Party {
   name: String!
   abbr: String!
+  wikipedia_url: String
+  wikidata_url: String
+  twitter_name: String
+  twitter_url: String
 }
 
 type PartyMembership {
@@ -88,6 +106,8 @@ type Commission {
   id: ID!
   name: String!
   abbr: String!
+  wikipedia_url: String
+  wikidata_url: String
 }
 
 type Compensation {
@@ -107,20 +127,31 @@ type Organisation {
   id: ID!
   updated: String!
   published: String!
+  updatedIso: String!
+  publishedIso: String!
   name: String!
+  abbr: String
   legalForm: String
   location: String
+  postalCode: String
+  countryIso2: String
   description: String
   uid: String
   website: String
   lobbyGroups: [LobbyGroup!]!
   connections: [Connection!]!
+  wikipedia_url: String
+  wikidata_url: String
+  twitter_name: String
+  twitter_url: String
 }
 
 type Guest implements Person {
   id: ID!
   updated: String!
   published: String!
+  updatedIso: String!
+  publishedIso: String!
   name: String!
   firstName: String!
   middleName: String
@@ -129,6 +160,14 @@ type Guest implements Person {
   gender: Gender
   # Format: DD.MM.YYYY
   dateOfBirth: String
+  website: String
+  wikipedia_url: String
+  wikidata_url: String
+  twitter_name: String
+  twitter_url: String
+  linkedin_url: String
+  facebook_name: String
+  facebook_url: String
   connections: [Connection!]!
   function: String,
   parliamentarian: Parliamentarian!
@@ -138,10 +177,14 @@ type LobbyGroup {
   id: ID!
   updated: String!
   published: String!
+  updatedIso: String!
+  publishedIso: String!
   name: String!
   description: String
   sector: String
   branch: Branch
+  wikipedia_url: String
+  wikidata_url: String
   commissions: [Commission!]!
   connections: [Connection]
 }
@@ -150,8 +193,12 @@ type Branch {
   id: ID!
   updated: String!
   published: String!
+  updatedIso: String!
+  publishedIso: String!
   name: String!
   description: String
+  wikipedia_url: String
+  wikidata_url: String
   commissions: [Commission!]!
   connections: [Connection]
 }
@@ -175,6 +222,8 @@ type Parliamentarian implements Person {
   id: ID!
   updated: String!
   published: String!
+  updatedIso: String!
+  publishedIso: String!
   name: String!
   parliamentId: ID!
   firstName: String!
@@ -202,6 +251,14 @@ type Parliamentarian implements Person {
   children: Int
   civilStatus: String
   website: String
+  wikipedia_url: String
+  wikidata_url: String
+  twitter_name: String
+  twitter_url: String
+  linkedin_url: String
+  facebook_name: String
+  facebook_url: String
+  parlament_biografie_url: String
   commissions: [Commission!]!
   connections: [Connection!]!
   guests: [Guest!]!

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -42,6 +42,8 @@ type Page {
   content: String
   lead: String!
   type: String!
+  # deprecated
+  created: String
   # DD.MM.YYYY HH:MM
   published: String
   updated: String

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "lobbywatch-rooster",
-  "version": "0.9.0",
+  "name": "lobbywatch-frontend",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -123,11 +123,26 @@
       "integrity": "sha512-+knTYetI5nWllRZ9wFcj7mYxelkiiFVRAAW/hl0ad8EnKHMH82tRlk40CapEnUHhp6Er5sCYkumQ8dngs3Q4zQ=="
     },
     "@ampproject/toolbox-validator-rules": {
-      "version": "2.5.4",
-      "resolved": "https://registry.npmjs.org/@ampproject/toolbox-validator-rules/-/toolbox-validator-rules-2.5.4.tgz",
-      "integrity": "sha512-bS7uF+h0s5aiklc/iRaujiSsiladOsZBLrJ6QImJDXvubCAQtvE7om7ShlGSXixkMAO0OVMDWyuwLlEy8V1Ing==",
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/@ampproject/toolbox-validator-rules/-/toolbox-validator-rules-2.7.4.tgz",
+      "integrity": "sha512-z3JRcpIZLLdVC9XVe7YTZuB3a/eR9s2SjElYB9AWRdyJyL5Jt7+pGNv4Uwh1uHVoBXsWEVQzNOWSNtrO3mSwZA==",
       "requires": {
-        "cross-fetch": "3.0.5"
+        "cross-fetch": "3.0.6"
+      },
+      "dependencies": {
+        "cross-fetch": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.6.tgz",
+          "integrity": "sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==",
+          "requires": {
+            "node-fetch": "2.6.1"
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
+        }
       }
     },
     "@apollo/protobufjs": {
@@ -4015,9 +4030,9 @@
       "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001156",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001156.tgz",
-      "integrity": "sha512-z7qztybA2eFZTB6Z3yvaQBIoJpQtsewRD74adw2UbRWwsRq3jIPvgrQGawBMbfafekQaD21FWuXNcywtTDGGCw=="
+      "version": "1.0.30001181",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001181.tgz",
+      "integrity": "sha512-m5ul/ARCX50JB8BSNM+oiPmQrR5UmngaQ3QThTTp5HcIIQGP/nPBs82BYLE+tigzm3VW+F4BJIhUyaVtEweelQ=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -6809,9 +6824,9 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
     "inline-style-prefixer": {
       "version": "3.0.8",

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "lobbywatch-rooster",
-  "version": "0.9.0",
+  "name": "lobbywatch-frontend",
+  "version": "1.0.0",
   "engines": {
     "node": "14.4.0"
   },
-  "description": "Lobbywatch 2017",
+  "description": "Lobbywatch.ch Frontend",
   "scripts": {
     "dev": "nodemon -w server.js -w routes.js -w constants.js -w graphql server.js",
     "build": "next build",

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -25,10 +25,16 @@ export default class MyDocument extends Document {
     }
   }
   render () {
-    const {css, env: {GA_TRACKING_ID}} = this.props
+    const {css, env: {GA_TRACKING_ID, PUBLIC_BASE_URL}, __NEXT_DATA__: {query: {locale}}} = this.props
+    const motivationComment = `/*
+🤔 You look like a curious person.
+💁 That's good, we need people like you!
+👉 Join us, ${PUBLIC_BASE_URL || ''}/de/seite/mitarbeiten
+*/`
     return (
-      <Html>
+      <Html lang={locale} dir="ltr">
         <Head>
+          <script dangerouslySetInnerHTML={{__html: motivationComment}}></script>
           <meta httpEquiv='X-UA-Compatible' content='IE=edge' />
           <style dangerouslySetInnerHTML={{ __html: fontFaces }} />
           {css ? <style dangerouslySetInnerHTML={{ __html: css }} /> : null}

--- a/pages/blog.js
+++ b/pages/blog.js
@@ -18,7 +18,7 @@ const blogQuery = gql`
     articles(locale: $locale, limit: 10, page: $page) {
       pages
       list {
-        created
+        published
         image
         lead
         title

--- a/pages/branch.js
+++ b/pages/branch.js
@@ -22,6 +22,8 @@ const branchQuery = gql`
       published
       name
       description
+      wikipedia_url
+      wikidata_url
       commissions {
         name
         abbr

--- a/pages/guest.js
+++ b/pages/guest.js
@@ -23,9 +23,18 @@ const guestQuery = gql`
       name
       occupation
       gender
+      wikipedia_url
+      wikidata_url
+      twitter_name
+      twitter_url
+      facebook_url
+      linkedin_url
       parliamentarian {
+        __typename
         id
         name
+        wikidata_url
+        parlament_biografie_url
       }
       function
       connections {
@@ -42,6 +51,8 @@ const guestQuery = gql`
           ... on Organisation {
             id
             name
+            uid
+            wikidata_url
           }
         }
       }

--- a/pages/index.js
+++ b/pages/index.js
@@ -11,13 +11,12 @@ import Message from '../src/components/Message'
 import Card from '../src/components/Card'
 import Grid, {GridItem} from '../src/components/Grid'
 import {H1, Link} from '../src/components/Styled'
-import {GREY_SOFT} from '../src/theme'
 
 const indexQuery = gql`
   query index($locale: Locale!) {
     articles(locale: $locale, limit: 2) {
       list {
-        created
+        published
         image
         lead
         title

--- a/pages/lobbygroup.js
+++ b/pages/lobbygroup.js
@@ -30,6 +30,8 @@ const lobbyGroupQuery = gql`
         name
         abbr
       }
+      wikipedia_url
+      wikidata_url
       connections {
         group
         to {
@@ -37,10 +39,14 @@ const lobbyGroupQuery = gql`
           ... on Organisation {
             id
             name
+            uid
+            wikidata_url
           }
           ... on Parliamentarian {
             id
             name
+            wikidata_url
+            parlament_biografie_url
           }
         }
         vias {

--- a/pages/organisation.js
+++ b/pages/organisation.js
@@ -23,9 +23,15 @@ const orgQuery = gql`
       name
       legalForm
       location
+      postalCode
+      countryIso2
       description
       uid
       website
+      wikipedia_url
+      wikidata_url
+      twitter_name
+      twitter_url
       lobbyGroups {
         id
         name
@@ -44,6 +50,8 @@ const orgQuery = gql`
           ... on Parliamentarian {
             id
             name
+            wikidata_url
+            parlament_biografie_url
           }
           ... on Organisation {
             id

--- a/pages/page.js
+++ b/pages/page.js
@@ -15,6 +15,8 @@ import {Router as RoutesRouter} from '../routes'
 const pageQuery = gql`
   query page($locale: Locale!, $path: [String!]!) {
     page(locale: $locale, path: $path) {
+      __typename
+      nid
       path
       translations {
         locale
@@ -23,9 +25,11 @@ const pageQuery = gql`
       statusCode
       title
       content
+      type
       lead
       image
-      created
+      published
+      updated
       author
     }
   }
@@ -53,7 +57,7 @@ const Page = ({loading, error, page, router: {query: {locale}}}) => (
   }}>
     <Loader loading={loading} error={error} render={() => (
       <div>
-        <MetaTags locale={locale} title={page.title} description={page.lead} image={page.image} />
+        <MetaTags locale={locale} title={page.title} description={page.lead} image={page.image} page={page}/>
         {!!page.image && (
           <Cover src={page.image} title={page.title} />
         )}
@@ -62,7 +66,7 @@ const Page = ({loading, error, page, router: {query: {locale}}}) => (
             <H1>{page.title}</H1>
           )}
           <Meta style={{marginBottom: 7}}>
-            {[page.created, page.author].filter(Boolean).join(' – ')}
+            {[page.published, page.author].filter(Boolean).join(' – ')}
           </Meta>
           <RawHtml dangerouslySetInnerHTML={{__html: page.content}} />
         </Center>

--- a/pages/page.js
+++ b/pages/page.js
@@ -31,6 +31,7 @@ const pageQuery = gql`
       published
       updated
       author
+      authorUid
     }
   }
 `

--- a/pages/parliamentarian.js
+++ b/pages/parliamentarian.js
@@ -25,6 +25,7 @@ const parliamentarianQuery = gql`
       gender
       age
       portrait
+      council
       councilTitle
       active
       canton
@@ -35,8 +36,15 @@ const parliamentarianQuery = gql`
       occupation
       civilStatus
       children
-      website
       parliamentId
+      website
+      wikipedia_url
+      wikidata_url
+      twitter_name
+      twitter_url
+      facebook_url
+      linkedin_url
+      parlament_biografie_url
       commissions {
         name
         abbr
@@ -47,8 +55,15 @@ const parliamentarianQuery = gql`
         }
       }
       guests {
+        __typename
         id
         name
+        wikipedia_url
+        wikidata_url
+        twitter_name
+        twitter_url
+        facebook_url
+        linkedin_url
       }
       connections {
         group
@@ -67,6 +82,8 @@ const parliamentarianQuery = gql`
           ... on Organisation {
             id
             name
+            uid
+            wikidata_url
           }
         }
         vias {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,3 @@
 User-Agent: *
-Disallow: 
+Disallow: /de/search
+Disallow: /fr/search

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -52,7 +52,7 @@ const pStyle = css({
   flexGrow: 1
 })
 
-const Card = ({image, path, title, author, created, lead, locale}) => {
+const Card = ({image, path, title, author, published, lead, locale}) => {
   return (
     <div {...containerStyle}>
       <RawRouteLink route='page' params={{locale, path}}>
@@ -63,7 +63,7 @@ const Card = ({image, path, title, author, created, lead, locale}) => {
       </RawRouteLink>
       <div {...bodyStyle}>
         <span {...metaRule}>
-          {[created, author].filter(Boolean).join(' – ')}
+          {[published, author].filter(Boolean).join(' – ')}
         </span>
         <P className={pStyle}>{lead}</P>
         <TextCenter>
@@ -80,7 +80,7 @@ Card.propTypes = {
   locale: PropTypes.oneOf(locales).isRequired,
   path: PropTypes.arrayOf(PropTypes.string).isRequired,
   title: PropTypes.string.isRequired,
-  created: PropTypes.string.isRequired,
+  published: PropTypes.string.isRequired,
   lead: PropTypes.string.isRequired,
   image: PropTypes.string
 }

--- a/src/components/Frame/Footer.js
+++ b/src/components/Frame/Footer.js
@@ -16,6 +16,7 @@ import Message from '../Message'
 import Loader from '../Loader'
 import {locales} from '../../../constants'
 import BlockRegion from '../BlockRegion'
+import { JsonLd } from '../JsonLd'
 
 const metaQuery = gql`
   query meta($locale: Locale!) {
@@ -105,7 +106,8 @@ const groupLinks = (links) => {
 }
 
 const Footer = ({loading, error, links, locale, router: {pathname, query}}) => (
-  <div style={{ marginTop: 20 }}>
+  <footer style={{ marginTop: 20 }}>
+    <JsonLd data={{"@context": "http://schema.org/", "@type": "WPFooter"}} />
     <Center>
       {!(pathname === '/page' && query.path === 'unterstuetzen') &&
         <BlockRegion locale={locale} region='rooster_home' compact first={pathname !== '/'} />
@@ -173,7 +175,7 @@ const Footer = ({loading, error, links, locale, router: {pathname, query}}) => (
         )} />
       </Center>
     </div>
-  </div>
+  </footer>
 )
 
 const FooterWithQuery = graphql(metaQuery, {

--- a/src/components/Frame/Header.js
+++ b/src/components/Frame/Header.js
@@ -22,7 +22,7 @@ import Logo from '../../assets/Logo'
 import SearchIcon from '../../assets/Search'
 import Menu from './Menu'
 import Toggle from './Toggle'
-import { linkRule } from '../Styled'
+import { JsonLd } from '../JsonLd'
 
 const titleStyle = css({
   fontSize: 24,
@@ -216,10 +216,11 @@ class Header extends Component {
     }
 
     return (
-      <div>
+      <header>
+        <JsonLd data={{"@context": "http://schema.org/", "@type": "WPHeader"}} />
         <Head>
           {localizedRoutes.map(({locale, href}) => (
-            <link key={locale} rel='alternate' hrefLang={locale} href={href} />
+            <link key={locale} rel='alternate' hreflang={locale} href={href} />
           ))}
         </Head>
         <div {...barStyle}>
@@ -258,7 +259,7 @@ class Header extends Component {
             })}
           </div>
         </div>}
-      </div>
+      </header>
     )
   }
 }

--- a/src/components/Frame/Header.js
+++ b/src/components/Frame/Header.js
@@ -220,7 +220,7 @@ class Header extends Component {
         <JsonLd data={{"@context": "http://schema.org/", "@type": "WPHeader"}} />
         <Head>
           {localizedRoutes.map(({locale, href}) => (
-            <link key={locale} rel='alternate' hreflang={locale} href={href} />
+            <link key={locale} rel='alternate' hrefLang={locale} href={href} />
           ))}
         </Head>
         <div {...barStyle}>

--- a/src/components/JsonLd.js
+++ b/src/components/JsonLd.js
@@ -1,0 +1,23 @@
+// cannot be used in <Head>
+// https://blog.haroen.me/json-ld-with-react
+export const JsonLd = ({ data }) =>
+<script
+  type="application/ld+json"
+  dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+/>;
+
+// cannot be used in <Head>
+export const JsonLds = ({ data }) => {
+  if (Array.isArray(data)) {
+    // return data.map((jsonLd, index) => JsonLd(jsonLd))
+    data.map((jsonLd, index) => (
+      <script
+        key={index}
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+    ))
+  } else if (data) {
+    return JsonLd(data)
+  }
+};

--- a/src/components/MetaTags.js
+++ b/src/components/MetaTags.js
@@ -281,6 +281,7 @@ const generateJsonLds = (locale, t, fromT, item, props, rest) => {
             "url": pageUrl,
             "author": {
               "@type": "Person",
+              "@id": `${baseId}uid-${item.authorUid}`,
               "name": item.author
             },
             "datePublished": convertDateToIso(item.published),

--- a/src/components/MetaTags.js
+++ b/src/components/MetaTags.js
@@ -6,8 +6,10 @@ import {set, nest} from 'd3-collection'
 import {descending} from 'd3-array'
 import {A, H2, Meta} from './Styled'
 import track from '../../lib/ga'
-import {PUBLIC_BASE_URL} from '../../constants'
+import {DRUPAL_BASE_URL, PUBLIC_BASE_URL} from '../../constants'
 import {matchRouteFromDatum} from '../utils/id'
+import {recursivelyRemoveNullsInPlace} from '../utils/helpers'
+import {convertDateToIso} from '../utils/formats'
 
 class Raw extends Component {
   componentDidMount () {
@@ -20,8 +22,11 @@ class Raw extends Component {
     track('send', 'pageview')
   }
   render () {
-    const {title, pageTitle, description, image, url} = this.props
+    const {title, pageTitle, description, image, url, shorturl, publishedIso, updatedIso, jsonLds, locale} = this.props
+    console.log('Metatags.props', this.props)
 
+    // Tempate from https://gist.github.com/oelna/192663f21e81e5467658332259b90a09
+    const rss_url = `${DRUPAL_BASE_URL || 'https://cms.lobbywatch.ch'}/${locale}/rss.xml`
     return (
       <Head>
         <title>{pageTitle}</title>
@@ -32,9 +37,36 @@ class Raw extends Component {
         <meta property='og:title' content={title} />
         <meta property='og:description' content={description} />
         {!!image && <meta property='og:image' content={image} />}
+
+        <meta name="fb:page_id" content="328676137285425" />
+
+        {!!shorturl && <link rel="shortlink" href={shorturl} />}
+        <link rel="alternate" type="application/rss+xml" title="RSS" href={rss_url} />
+
         <meta name='twitter:card' content={image ? 'summary_large_image' : 'summary'} />
         <meta name='twitter:site' content='@Lobbywatch_CH' />
         <meta name='twitter:creator' content='@Lobbywatch_CH' />
+        <meta name='twitter:description' content={description} />
+        {!!image && <meta name="twitter:image" content={image} />}
+
+        <link rel="schema.DC" href="http://purl.org/dc/elements/1.1/" />
+        <link rel="schema.DCTERMS" href="http://purl.org/dc/terms/" />
+
+        <meta name="DC.Title" content={title} />
+        <meta name="DC.Language" content={locale} />
+        <meta name="DC.Publisher" content="Lobbywatch.ch" />
+        {!!publishedIso && <meta name="DC.Created" content={publishedIso} />}
+        {!!updatedIso && <meta name="DC.Modified" content={updatedIso} />}
+
+        {!!jsonLds &&
+            jsonLds.map((jsonLd, index) => (
+            <script
+              key={index}
+              type="application/ld+json"
+              dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+            />
+            ))
+        }
       </Head>
     )
   }
@@ -145,7 +177,350 @@ const description = (item, t) => {
   }
 }
 
-const MetaTags = ({locale, t, fromT, data, ...rest}) => {
+/**
+ * Generates an array with Schema.org objects for Lobbywatch data or CMS pages.
+ * This objects can be converted to JSON metadata of the webpage.
+ *
+ * JSON-LD:
+ * https://json-ld.org/ (home), https://json-ld.org/spec/latest/json-ld/ (spec)
+ * https://www.w3.org/TR/json-ld11/ (JSON-LD spec)
+ * https://jsonld.com/website/ (examples), https://json-ld.org/playground/, https:// jsonld.com/json-ld-generator/
+ *
+ * Schema.org:
+ * https://schema.org/docs/datamodel.html (schema.org basics)
+ * https://developers.google.com/search/docs/data-types/dataset
+ * https://search.google.com/test/rich-results
+ */
+const generateJsonLds = (locale, t, fromT, item, props, rest) => {
+  const MAX_HEADLINE = 110
+  const jsonLds = []
+  const baseUrl = PUBLIC_BASE_URL || ''
+  const baseId = baseUrl + '#'
+  console.log('generateJsonLds', locale, t, fromT, item, props, rest)
+
+  // All fields of the objects are filled, even with null or undefined values.
+  // At the end, all empty (null or undefined) values are cleaned before returning.
+  const lobbywatchOrganization = {
+    "@context": "https://schema.org",
+    "@type": "NewsMediaOrganization",
+    "@id" : "https://lobbywatch.ch",
+    "additionalType": [
+      "NGO"
+    ],
+    "name": "Lobbywatch.ch",
+    "foundingDate": "2014",
+    "logo": [
+      `${baseUrl}/static/android-chrome-192x192.png`,
+      `${baseUrl}/static/favicon-16x16.png`,
+      `${baseUrl}/static/favicon-32x32.png`,
+      `${baseUrl}/apple-touch-icon.png`,
+    ],
+    // "description": ,
+    "url": "https://lobbywatch.ch",
+    "nonprofitStatus": "NonprofitType",
+    "sameAs": [
+      "https://www.facebook.com/lobbywatch",
+      "https://twitter.com/Lobbywatch_CH",
+      "https://www.instagram.com/lobbywatch_ch/",
+      ]
+  }
+
+  jsonLds.push({
+    "@context": "http://schema.org",
+    "@type": "WebSite",
+    "name": "Lobbywatch.ch",
+    "@id" : `${baseId}website`,
+    "url": "https://lobbywatch.ch",
+    // "description": ; TODO de and fr text
+    "sameAs": [
+      "https://www.facebook.com/lobbywatch",
+      "https://twitter.com/Lobbywatch_CH",
+    ],
+    "potentialAction": {
+      "@type": "SearchAction",
+      "target": `${baseUrl}/${locale}/search?term={search_term}`,
+      // "query-input" seems to be non-standard, but used by Google
+      "query-input": "required name=search_term"
+    },
+    "creator": lobbywatchOrganization,
+  })
+
+  const affiliations = (connections) => connections.filter(innerItem => innerItem.to.__typename === 'Organisation').map(innerItem => {
+    const linkedItem = innerItem.to
+    return {
+      "@context": "https://schema.org",
+      "@type": "Organization",
+      "@id": baseId + linkedItem.id,
+      "identifier" : linkedItem.uid,
+      "name": linkedItem.name,
+      "url": baseUrl + matchRouteFromDatum(linkedItem, locale).as,
+      "sameAs": [
+        linkedItem.wikidata_url,
+      ],
+    }
+  })
+
+  switch (item?.__typename) {
+    case 'Page': {
+      const pageUrl = `${baseUrl}/${locale}/` + item.path.join('/')
+      switch (item.type) {
+        case 'article' : {
+          // https://schema.org/NewsArticle, https://jsonld.com/news-article/
+          // https://schema.org/BlogPosting, https://jsonld.com/blog-post/
+          jsonLds.push({
+            "@context": "https://schema.org",
+            "@type": "NewsArticle",
+            "additionalType": [
+              "BlogPosting"
+            ],
+            "@id": baseId + item.nid,
+            "headline": item.title?.substr(0, MAX_HEADLINE),
+            "name": item.title,
+            "description": item.lead,
+            "inLanguage": locale,
+            "url": pageUrl,
+            "author": {
+              "@type": "Person",
+              "name": item.author
+            },
+            "datePublished": convertDateToIso(item.published),
+            "dateModified": convertDateToIso(item.updated),
+            "image": item.image,
+            "publisher": lobbywatchOrganization,
+          })
+          break;
+        }
+        case 'page': {
+          // https://schema.org/WebPage, https://jsonld.com/web-page/
+          jsonLds.push({
+            "@context": "https://schema.org",
+            "@type": "WebPage",
+            "@id": baseId + item.nid,
+            "name": item.title,
+            "description": item.lead,
+            "url": pageUrl,
+          })
+        break;
+        }
+      }
+      break;
+    }
+    case 'Parliamentarian': {
+      // https://schema.org/Person, https://jsonld.com/person/
+      jsonLds.push({
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "@id": baseId + item.id,
+        "jobTitle": [
+          item.councilTitle,
+          item.occupation,
+        ],
+        "name": item.name,
+        "givenName": item.firstName,
+        "familyName": item.lastName,
+        "additionalName": item.middleName,
+        "birthDate": convertDateToIso(item.dateOfBirth),
+        "gender": item.gender === 'M' ? 'Male' : 'Female',
+        "nationality": "CH",
+        "url": props.url,
+        "image" : item.portrait,
+        "sameAs": [
+          item.wikidata_url,
+          item.wikipedia_url,
+          item.twitter_url,
+          item.linkedin_url,
+          item.facebook_url,
+          item.parlament_biografie_url,
+          item.website,
+        ],
+        "address": {
+          "@type": "PostalAddress",
+          "addressRegion": item.canton,
+          "addressCountry": "CH",
+        },
+        "memberOf": [
+          item.council,
+          item.partyMembership.party.abbr,
+          // commissions
+        ],
+        "knows": item.guests.map(linkedItem => {
+          return {
+            "@context": "https://schema.org",
+            "@type": "Person",
+            "@id": baseId + linkedItem.id,
+            "name": linkedItem.name,
+            "url": baseUrl + matchRouteFromDatum(linkedItem, locale).as,
+            "sameAs": [
+              linkedItem.wikidata_url,
+              linkedItem.wikipedia_url,
+              linkedItem.twitter_url,
+              linkedItem.linkedin_url,
+              linkedItem.facebook_url,
+            ],
+          }
+        }),
+        "affiliation": affiliations(item.connections),
+      })
+      break;
+    }
+    case 'Guest': {
+      const guestItem = item
+      const linkedItem = item.parliamentarian
+      jsonLds.push({
+        "@context": "https://schema.org",
+        "@type": "Person",
+        "@id": baseId + guestItem.id,
+        "jobTitle": guestItem.occupation,
+        "name": guestItem.name,
+        "givenName": guestItem.firstName,
+        "familyName": guestItem.lastName,
+        "additionalName": guestItem.middleName,
+        "birthDate": convertDateToIso(guestItem.dateOfBirth),
+        "gender": guestItem.gender === 'M' ? 'Male' : 'Female',
+        "url": props.url,
+        "sameAs": [
+          guestItem.wikidata_url,
+          guestItem.wikipedia_url,
+          guestItem.twitter_url,
+          guestItem.linkedin_url,
+          guestItem.facebook_url,
+        ],
+        "knows": {
+          "@context": "https://schema.org",
+          "@type": "Person",
+          "@id": baseId + linkedItem.id,
+          "name": linkedItem.name,
+          "url": baseUrl + matchRouteFromDatum(linkedItem, locale).as,
+          "sameAs": [
+            linkedItem.wikidata_url,
+            linkedItem.twitter_url,
+            item.parlament_biografie_url,
+          ],
+        },
+        "affiliation": affiliations(item.connections),
+      })
+      break;
+    }
+    case 'Organisation': {
+      // https://schema.org/Organization, https://jsonld.com/organization/
+      jsonLds.push({
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "@id": baseId + item.id,
+        "identifier" : item.uid,
+        "name": item.name,
+        "description": item.description,
+        "url": props.url,
+        "address": {
+          "@type": "PostalAddress",
+          "addressLocality": item.location,
+          "postalCode": item.postalCode,
+          "addressCountry": item.countryIso2
+        },
+        "sameAs": [
+          item.wikipedia_url,
+          item.wikidata_url,
+          item.twitter_url,
+          item.website
+        ],
+        "memberOf": item.lobbyGroups.map(linkedItem => {
+          return {
+            "@context": "https://schema.org",
+            "@type": "Organization",
+            "@id": baseId + linkedItem.id,
+            "name": linkedItem.name,
+            "url": baseUrl + matchRouteFromDatum(linkedItem, locale).as,
+          }
+        }),
+        // "knows" is not specified for Organization, maybe search enginges are not that strict
+        "knows": item.connections.filter(linkedItem => linkedItem.__typename === 'Parliamentarian').map(linkedItem => {
+          return {
+            "@context": "https://schema.org",
+            "@type": "Person",
+            "@id": baseId + linkedItem.id,
+            "name": linkedItem.name,
+            "url": baseUrl + matchRouteFromDatum(linkedItem, locale).as,
+            "sameAs": [
+              linkedItem.wikidata_url,
+            ],
+          }
+        }),
+      })
+      break;
+    }
+    case 'LobbyGroup': {
+      const linkedItem = item.branch
+      jsonLds.push({
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "@id": baseId + item.id,
+        "url": props.url,
+        "name": item.name,
+        "description": item.description,
+        "sameAs": [
+          item.wikipedia_url,
+          item.wikidata_url,
+        ],
+        "memberOf": {
+            "@context": "https://schema.org",
+            "@type": "Organization",
+            "@id": baseId + linkedItem.id,
+            "name": linkedItem.name,
+            "url": baseUrl + matchRouteFromDatum(linkedItem, locale).as,
+        },
+        "member": item.connections.filter(linkedItem => ['Organisation', 'Parliamentarian'].includes(linkedItem.to.__typename)).map(innerItem => {
+          const linkedItem = innerItem.to
+          return {
+            "@context": "https://schema.org",
+            "@type": linkedItem.__typename === 'Parliamentarian' ? 'Person' : "Organization",
+            "@id": baseId + linkedItem.id,
+            "name": linkedItem.name,
+            "url": baseUrl + matchRouteFromDatum(linkedItem, locale).as,
+            "sameAs": [
+              item.wikidata_url,
+            ],
+          }
+        }),
+      })
+      break;
+    }
+    case 'Branch': {
+      jsonLds.push({
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "@id": baseId + item.id,
+        "url": props.url,
+        "name": item.name,
+        "description": item.description,
+        "sameAs": [
+          item.wikipedia_url,
+          item.wikidata_url,
+        ],
+        "member": item.connections.filter(linkedItem => linkedItem.to.__typename === 'LobbyGroup').map(innerItem => {
+          const linkedItem = innerItem.to
+          return {
+            "@context": "https://schema.org",
+            "@type": "Organization",
+            "@id": baseId + linkedItem.id,
+            "name": linkedItem.name,
+            "url": baseUrl + matchRouteFromDatum(linkedItem, locale).as,
+          }
+        }),
+      })
+      break;
+    }
+    default: {
+
+    }
+  }
+
+  console.log('jsonLds', jsonLds)
+  // FIXME recursivelyRemoveNullsInPlace(jsonLds)
+
+  return jsonLds
+}
+
+const MetaTags = ({locale, t, fromT, data, page, ...rest}) => {
   let props = rest
   if (fromT) {
     props = {
@@ -157,15 +532,22 @@ const MetaTags = ({locale, t, fromT, data, ...rest}) => {
     props = {
       ...props,
       title: title(data, t),
-      description: description(data, t)
+      description: description(data, t),
+      publishedIso: convertDateToIso(data.published),
+      updatedIso: convertDateToIso(data.updated),
     }
 
     const detailRoute = matchRouteFromDatum(data, locale)
     if (detailRoute) {
       props.url = `${PUBLIC_BASE_URL || ''}${detailRoute.as}`
+      props.shorturl = `${PUBLIC_BASE_URL || ''}${detailRoute.short}`
     }
+  } else if (page) {
+    props.url = `${PUBLIC_BASE_URL || ''}/${locale}/` + page.path.join('/')
+    props.shorturl = `${PUBLIC_BASE_URL || ''}/${locale}/node/${page.nid}`
   }
   props.pageTitle = pageTitle(props.title)
+  props.jsonLds = generateJsonLds(locale, t, fromT, data ?? page, props, rest)
   return <Raw {...props} />
 }
 

--- a/src/utils/formats.js
+++ b/src/utils/formats.js
@@ -8,3 +8,8 @@ const swissNumbers = formatLocale({
 })
 export const chfFormat = swissNumbers.format('$,.0f')
 export const numberFormat = swissNumbers.format(',')
+
+/** Converts dd.mm.yyyy to yyyy-mm-dd. Ignores time */
+export const convertDateToIso = (date) => {
+  return date ? date.replace(/^([0-2]\d|3[01])\.([0]\d|1[0-2])\.(\d{4}).*$/, '$3-$2-$1') : {}
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -46,3 +46,20 @@ export const shallowEqual = (a, b) => {
 
   return countA === countB
 }
+
+// Compact arrays with null entries; delete keys from objects with null value
+// From https://stackoverflow.com/questions/18515254/recursively-remove-null-values-from-javascript-object
+// And https://stackoverflow.com/questions/41828787/javascript-filter-null-object-properties
+export const recursivelyRemoveNullsInPlace = (obj) => {
+  const isArray = Array.isArray(obj)
+  for (var k in obj) {
+    if (obj[k] === null || obj[k] === undefined || obj[k].length === 0) {
+      isArray ? obj.splice(k, 1) : delete obj[k]
+    } else if (typeof obj[k] == "object" || Array.isArray(obj[k])) {
+      recursivelyRemoveNullsInPlace(obj[k])
+      if (obj[k].length === 0) {
+        isArray ? obj.splice(k, 1) : delete obj[k]
+      }
+    }
+  }
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -50,15 +50,29 @@ export const shallowEqual = (a, b) => {
 // Compact arrays with null entries; delete keys from objects with null value
 // From https://stackoverflow.com/questions/18515254/recursively-remove-null-values-from-javascript-object
 // And https://stackoverflow.com/questions/41828787/javascript-filter-null-object-properties
+// Reverse iterate https://stackoverflow.com/questions/9882284/looping-through-array-and-removing-items-without-breaking-for-loop
 export const recursivelyRemoveNullsInPlace = (obj) => {
-  const isArray = Array.isArray(obj)
-  for (var k in obj) {
-    if (obj[k] === null || obj[k] === undefined || obj[k].length === 0) {
-      isArray ? obj.splice(k, 1) : delete obj[k]
-    } else if (typeof obj[k] == "object" || Array.isArray(obj[k])) {
-      recursivelyRemoveNullsInPlace(obj[k])
-      if (obj[k].length === 0) {
-        isArray ? obj.splice(k, 1) : delete obj[k]
+  if (Array.isArray(obj)) {
+    var k = obj.length
+    while (k--) {
+      if (obj[k] === null || obj[k] === undefined || obj[k].length === 0) {
+        obj.splice(k, 1) // splice reindexes array, thus a forward loop does not work
+      } else if (typeof obj[k] == "object" || Array.isArray(obj[k])) {
+        recursivelyRemoveNullsInPlace(obj[k])
+        if (obj[k].length === 0) {
+          obj.splice(k, 1) // splice reindexes array, thus a forward loop does not work
+        }
+      }
+    }
+  } else { // object
+    for (var k in obj) {
+      if (obj[k] === null || obj[k] === undefined || obj[k].length === 0) {
+        delete obj[k]
+      } else if (typeof obj[k] == "object" || Array.isArray(obj[k])) {
+        recursivelyRemoveNullsInPlace(obj[k])
+        if (obj[k].length === 0) {
+          delete obj[k]
+        }
       }
     }
   }

--- a/src/utils/id.js
+++ b/src/utils/id.js
@@ -1,7 +1,7 @@
 import routes from '../../routes'
 
 export const getRawId = ({ id, __typename }, locale) => id
-  .split('-')
+  ?.split('-')
   .filter(part => part !== __typename && part !== locale)
   .join('-')
 
@@ -18,9 +18,15 @@ export const matchRouteFromDatum = (datum, locale) => {
     name: datum.name
   }
 
+  const shortParams = {
+    locale,
+    id: getRawId(datum, locale)
+  }
+
   return {
     routeName,
     params,
-    as: route.getAs(params)
+    as: route.getAs(params),
+    short: route.getAs(shortParams)
   }
 }


### PR DESCRIPTION
- rename page.created to published (the same as data)
- add more fields in Graphql schema
- add json-ld metadata to frondend #49
- add Dublin Core (DC) metadata #39
- round represented population #27
- add metadata for Twitter #23
- add meta data for Facebook #22
- add RSS link to head #4

Es hat noch 3 console.log() und TODO und FIXME drin. Ich werde noch testen und diese dann rausnehmen.