### PR TITLE
fix no party (meta tags)

### DIFF
--- a/src/components/MetaTags.js
+++ b/src/components/MetaTags.js
@@ -367,7 +367,6 @@ const generateJsonLds = (locale, t, fromT, item, props, rest) => {
         },
         "memberOf": [
           item.council == 'NR' ? NR : SR,
-          item.partyMembership.party.abbr,
           // commissions
         ],
         "knows": item.guests.map(linkedItem => {


### PR DESCRIPTION
bei parteilosen knallts.

Entferne Partei bei memberOf. Die Abkürzung alleine war so wie so nicht schema.org konform.