### PR TITLE
Fix Unexpected Error When Navigating to Detail Pages

### DIFF
--- a/lib/apolloClient.js
+++ b/lib/apolloClient.js
@@ -1,6 +1,5 @@
 import {useMemo} from 'react'
 import {ApolloClient, HttpLink, InMemoryCache} from '@apollo/client'
-import {getDataFromTree} from '@apollo/client/react/ssr'
 import deepMerge from './deepMerge'
 
 import {GRAPHQL_URI} from '../constants'
@@ -75,17 +74,24 @@ export function addApolloState(client, pageProps) {
 
 export function withInitialProps(Page) {
   Page.getInitialProps = async ({ ctx, AppTree }) => {
-    const apolloClient = initializeApollo()
+    if (!process.browser) {
+      const {getDataFromTree} = require('@apollo/client/react/ssr')
+      const apolloClient = initializeApollo()
+      await getDataFromTree(
+        <AppTree
+          apolloClient={apolloClient}
+          serverContext={ctx}
+        />
+      )
 
-    await getDataFromTree(
-      <AppTree
-        apolloClient={apolloClient}
-        serverContext={ctx}
-      />
-    )
-
+      return {
+        [APOLLO_STATE_PROP_NAME]: apolloClient.cache.extract()
+      }
+    }
+    // client side apollo runs normally
     return {
-      [APOLLO_STATE_PROP_NAME]: apolloClient.cache.extract()
+      // https://nextjs.org/docs/messages/empty-object-getInitialProps
+      _skipEmptyWarning: true
     }
   }
   return Page

--- a/pages/[locale]/daten/organisation/[id]/[[...name]].js
+++ b/pages/[locale]/daten/organisation/[id]/[[...name]].js
@@ -1,8 +1,7 @@
 import React from 'react'
 
-import {gql} from '@apollo/client'
-import {graphql} from '@apollo/client/react/hoc'
-import {withRouter} from 'next/router'
+import {gql, useQuery} from '@apollo/client'
+import {useRouter} from 'next/router'
 
 import Loader from 'src/components/Loader'
 import Frame, {Center} from 'src/components/Frame'
@@ -10,10 +9,9 @@ import MetaTags, {GooglePreview} from 'src/components/MetaTags'
 import Connections from 'src/components/Connections'
 import DetailHead from 'src/components/DetailHead'
 import {A, Meta} from 'src/components/Styled'
-import {withT} from 'src/components/Message'
 import {DRUPAL_BASE_URL, DEBUG_INFORMATION} from 'constants'
 
-import {withInitialProps} from 'lib/apolloClient'
+import {createGetStaticProps} from 'lib/apolloClientSchemaLink'
 
 const orgQuery = gql`
   query getOrganisation($locale: Locale!, $id: ID!) {
@@ -79,55 +77,64 @@ const CONNECTION_WEIGHTS = {
   Organisation: 0.1
 }
 
-const Org = ({loading, error, organisation, t, locale, id}) => (
-  <Loader loading={loading} error={error} render={() => {
-    const {__typename, name} = organisation
-    const rawId = id.replace(`${__typename}-`, '')
-    const path = `/${locale}/daten/organisation/${rawId}/${name}`
-    return (
-      <div>
-        <MetaTags locale={locale} data={organisation} />
-        <Center>
-          <DetailHead locale={locale} data={organisation} />
-        </Center>
-        <Connections
-          locale={locale}
-          data={organisation.connections}
-          groupByDestination
-          connectionWeight={connection => CONNECTION_WEIGHTS[connection.to.__typename]} />
-        {DEBUG_INFORMATION && <Center>
-          <Meta>
-            Original Profil:
-            {' '}<A target='_blank' href={`${DRUPAL_BASE_URL}${path}`}>Staging</A>
-            {', '}<A target='_blank' href={`https://lobbywatch.ch${path}`}>Live</A>
-          </Meta>
-          <GooglePreview data={organisation} t={t} path={path} />
-        </Center>}
-      </div>
-    )
-  }} />
-)
+const Org = () => {
+  const {query: {locale, id}, isFallback} = useRouter()
+  const {loading, error, data} = useQuery(orgQuery, {
+    variables: {
+      locale,
+      id
+    }
+  })
 
-const OrgWithQuery = withT(graphql(orgQuery, {
-  props: ({data, ownProps: {serverContext, t}}) => {
-    const notFound = !data.loading && !data.getOrganisation
-    if (serverContext) {
-      if (notFound) {
-        serverContext.res.statusCode = 404
+  return <Frame>
+    <Loader loading={loading || isFallback} error={error} render={() => {
+      const { getOrganisation: organisation } = data
+      const {__typename, name} = organisation
+      const rawId = id.replace(`${__typename}-`, '')
+      const path = `/${locale}/daten/organisation/${rawId}/${name}`
+      return (
+        <div>
+          <MetaTags locale={locale} data={organisation} />
+          <Center>
+            <DetailHead locale={locale} data={organisation} />
+          </Center>
+          <Connections
+            locale={locale}
+            data={organisation.connections}
+            groupByDestination
+            connectionWeight={connection => CONNECTION_WEIGHTS[connection.to.__typename]} />
+          {DEBUG_INFORMATION && <Center>
+            <Meta>
+              Original Profil:
+              {' '}<A target='_blank' href={`${DRUPAL_BASE_URL}${path}`}>Staging</A>
+              {', '}<A target='_blank' href={`https://lobbywatch.ch${path}`}>Live</A>
+            </Meta>
+            <GooglePreview data={organisation} t={t} path={path} />
+          </Center>}
+        </div>
+      )
+    }} />
+  </Frame>
+}
+
+export const getStaticProps = createGetStaticProps({
+  pageQuery: orgQuery,
+  getVariables: ({ params: { id } }) => ({
+    id
+  }),
+  getCustomStaticProps: ({ data }) => {
+    if (!data.getOrganisation) {
+      return {
+        notFound: true
       }
     }
-    return {
-      loading: data.loading,
-      error: data.error || (notFound && t('organisation/error/404')),
-      organisation: data.getOrganisation
-    }
   }
-})(Org))
+})
+export async function getStaticPaths() {
+  return {
+    paths: [],
+    fallback: 'blocking'
+  }
+}
 
-const Page = ({router: {query: {locale, id}}, serverContext}) => (
-  <Frame>
-    <OrgWithQuery locale={locale} id={id} serverContext={serverContext} />
-  </Frame>
-)
-
-export default withInitialProps(withRouter(Page))
+export default Org


### PR DESCRIPTION
See changes in `lib/apolloClient.js`. Basically I forgot to limit `getDataFromTree` in the `withInitialProps` helper to SSR. Caused really odd bugs which were hard to spot because they mostly failed silently.

Because I didn't find the bug initially I started to rewrite detail pages from `withInitialProps` to `createGetStaticProps` which also solved the issue. Eventually I caught on and solved the root bug. Leaving the lobby group detail page on the old fixed `withInitialProps` for now—want to see that I actually fixed it ;-)