### PR TITLE
Use Next Image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1756,19 +1756,19 @@
       "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="
     },
     "@next/env": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.2.0.tgz",
-      "integrity": "sha512-tsWBsn1Rb6hXRaHc/pWMCpZ4Ipkf3OCbZ54ef5ukgIyEvzzGdGFXQshPP2AF7yb+8yMpunWs7vOMZW3e8oPF6A=="
+      "version": "10.2.1-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-10.2.1-canary.8.tgz",
+      "integrity": "sha512-5DiV/C6liAvXhvE+23Kj4Cayqp/HzhKi7uqKdYGDvR6A7lsoz5obrEfMcgHyvX2zyfOMmEkqKiOj9LNLj5jKzw=="
     },
     "@next/polyfill-module": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.2.0.tgz",
-      "integrity": "sha512-Nl3GexIUXsmuggkUqrRFyE/2k7UI44JaVzSywtXEyHzxpZm2a5bdMaWuC89pgLiFDDOqmbqyLAbtwm5lNxa7Eg=="
+      "version": "10.2.1-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/polyfill-module/-/polyfill-module-10.2.1-canary.8.tgz",
+      "integrity": "sha512-6c+o/Pn7YYbPNto9DoDgo2C8USeJ7rFH4NqwKUwDr2cykH63Qoc5qkpN0/jpImhJXQxyCtCQtK+0NeMLxEhTlA=="
     },
     "@next/react-dev-overlay": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.2.0.tgz",
-      "integrity": "sha512-PRIAoWog41hLN4iJ8dChKp4ysOX0Q8yiNQ/cwzyqEd3EjugkDV5OiKl3mumGKaApJaIra1MX6j1wgQRuLhuWMA==",
+      "version": "10.2.1-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/react-dev-overlay/-/react-dev-overlay-10.2.1-canary.8.tgz",
+      "integrity": "sha512-Af9s0cMqMIf22ovXYuKAV8PyGFRd8PFzbPNl4awUB5NKecdZFeFgSaImEJc1vPn1mGtUJU6DMyYv2U33ic8GdQ==",
       "requires": {
         "@babel/code-frame": "7.12.11",
         "anser": "1.4.9",
@@ -1829,9 +1829,9 @@
       }
     },
     "@next/react-refresh-utils": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.2.0.tgz",
-      "integrity": "sha512-3I31K9B4hEQRl7yQ44Umyz+szHtuMJrNdwsgJGhoEnUCXSBRHp5wv5Zv8eDa2NewSbe53b2C0oOpivrzmdBakw=="
+      "version": "10.2.1-canary.8",
+      "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-10.2.1-canary.8.tgz",
+      "integrity": "sha512-waM0pLru/1gMgvRvpvVjqxg/BqW72pZcGSyGg+FJJfhbf4LIqLFb8YlXYcpVFTsSQS0hpcgln4o3LC/YQohwEg=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
@@ -5998,16 +5998,16 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "next": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/next/-/next-10.2.0.tgz",
-      "integrity": "sha512-PKDKCSF7s82xudu3kQhOEaokxggpbLEWouEUtzP6OqV0YqKYHF+Ff+BFLycEem8ixtTM2M6ElN0VRJcskJfxPQ==",
+      "version": "10.2.1-canary.8",
+      "resolved": "https://registry.npmjs.org/next/-/next-10.2.1-canary.8.tgz",
+      "integrity": "sha512-a9m9pqD0cTgmWpfD0UjsrRlYdfiECUnOE4oF6+pWN5ENTR7B111a5q3P9KyBG2zkXUMZzvjUiftnriOEUWdjOw==",
       "requires": {
         "@babel/runtime": "7.12.5",
         "@hapi/accept": "5.0.1",
-        "@next/env": "10.2.0",
-        "@next/polyfill-module": "10.2.0",
-        "@next/react-dev-overlay": "10.2.0",
-        "@next/react-refresh-utils": "10.2.0",
+        "@next/env": "10.2.1-canary.8",
+        "@next/polyfill-module": "10.2.1-canary.8",
+        "@next/react-dev-overlay": "10.2.1-canary.8",
+        "@next/react-refresh-utils": "10.2.1-canary.8",
         "@opentelemetry/api": "0.14.0",
         "assert": "2.0.0",
         "ast-types": "0.13.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "gsheets": "^2.0.0",
     "isomorphic-unfetch": "^3.1.0",
     "lru-cache": "^6.0.0",
-    "next": "^10.2.0",
+    "next": "^10.2.1-canary.8",
     "prop-types": "^15.6.0",
     "querystring": "^0.2.1",
     "react": "^17.0.2",

--- a/pages/[locale]/artikel/archiv.js
+++ b/pages/[locale]/artikel/archiv.js
@@ -50,7 +50,7 @@ const Blog = ({ loading, error, articles, page, locale }) => (
         <Grid>
           {articles.list.map((article, index) => (
             <GridItem key={index}>
-              <Card locale={locale} {...article} />
+              <Card locale={locale} {...article} priority={index < 2} />
             </GridItem>
           ))}
         </Grid>

--- a/pages/[locale]/index.js
+++ b/pages/[locale]/index.js
@@ -61,7 +61,7 @@ const Index = () => {
               <Grid>
                 {data.articles.list.map((article, index) => (
                   <GridItem key={index}>
-                    <Card locale={locale} {...article} />
+                    <Card locale={locale} {...article} priority />
                   </GridItem>
                 ))}
               </Grid>

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import Link from 'next/link'
-// import Image from 'next/image'
+import Image from 'next/image'
 
 import { h2Rule, metaRule, ButtonLink, P, TextCenter } from './Styled'
 import Message from './Message'
@@ -59,15 +59,14 @@ const Card = ({ image, path, title, author, published, lead, locale }) => {
   return (
     <div {...containerStyle}>
       <Link href={fullPath}>
-        <a {...headStyle} style={{ backgroundImage: image && `url(${image})` }}>
-          {/* Next Image consumes too much memory on Heroku */}
-          {/* <Image
+        <a {...headStyle}>
+          <Image
             src={image}
             priority
             layout='fill'
             objectFit='cover'
             quality={90}
-          /> */}
+          />
           <span {...shadeStyle} />
           <h2 {...titleStyle}>{title}</h2>
         </a>

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -7,7 +7,7 @@ import { h2Rule, metaRule, ButtonLink, P, TextCenter } from './Styled'
 import Message from './Message'
 
 import { css } from 'glamor'
-import { WHITE, GREY_SOFT, GREY_LIGHT } from '../theme'
+import { WHITE, GREY_SOFT } from '../theme'
 import { locales } from '../../constants'
 
 const containerStyle = css({
@@ -20,9 +20,6 @@ const containerStyle = css({
 })
 const headStyle = css({
   textDecoration: 'none',
-  backgroundSize: 'cover',
-  backgroundPosition: 'center',
-  backgroundColor: GREY_LIGHT,
   minHeight: 160,
   padding: '16px 24px',
   position: 'relative',

--- a/src/components/Card.js
+++ b/src/components/Card.js
@@ -51,7 +51,16 @@ const pStyle = css({
   flexGrow: 1,
 })
 
-const Card = ({ image, path, title, author, published, lead, locale }) => {
+const Card = ({
+  image,
+  path,
+  title,
+  author,
+  published,
+  lead,
+  locale,
+  priority,
+}) => {
   const fullPath = `/${locale}/${path.join('/')}`
   return (
     <div {...containerStyle}>
@@ -59,7 +68,8 @@ const Card = ({ image, path, title, author, published, lead, locale }) => {
         <a {...headStyle}>
           <Image
             src={image}
-            priority
+            priority={priority}
+            sizes='370px'
             layout='fill'
             objectFit='cover'
             quality={90}

--- a/src/components/Cover.js
+++ b/src/components/Cover.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { css } from 'glamor'
 
-import { mediaM, mediaL } from '../theme'
+import { mediaM } from '../theme'
 import { H1 } from './Styled'
 import { preventWidow } from '../utils/helpers'
 
@@ -11,7 +11,7 @@ export const NARROW_WIDTH = 640
 const coverStyle = css({
   width: '100%',
   position: 'relative',
-  [mediaL]: {
+  [mediaM]: {
     minHeight: 500,
     height: ['400px', '50vh'],
     backgroundSize: 'cover',
@@ -21,7 +21,7 @@ const coverStyle = css({
 const coverImageStyle = css({
   display: 'block',
   width: '100%',
-  [mediaL]: {
+  [mediaM]: {
     display: 'none',
   },
 })
@@ -62,7 +62,7 @@ const titleStyle = css({
 const Cover = ({ src, title }) => (
   <div
     {...coverStyle}
-    {...css({ [mediaL]: { backgroundImage: `url('${src}')` } })}
+    {...css({ [mediaM]: { backgroundImage: `url('${src}')` } })}
   >
     <img {...coverImageStyle} src={src} alt='' />
     <div {...leadStyle}>

--- a/src/components/DetailHead.js
+++ b/src/components/DetailHead.js
@@ -1,5 +1,8 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
+import Image from 'next/image'
+import { css } from 'glamor'
+
 import { A, StyledLink, Clear, h1Rule, metaRule, TextCenter } from './Styled'
 import { withT } from './Message'
 import { ContextBoxValue } from './ContextBox'
@@ -10,7 +13,6 @@ import { itemPath } from '../utils/routes'
 import { GREY_LIGHT } from '../theme'
 import Icons from '../assets/TypeIcons'
 import ExpandIcon from '../assets/Expand'
-import { css } from 'glamor'
 
 const titleStyle = css(h1Rule, {
   marginTop: 0,
@@ -22,10 +24,12 @@ const metaStyle = css(metaRule, {
 const symbolStyle = css({
   display: 'inline-block',
 })
+const SYMBOL_SIZE = 64
 const imageStyle = css({
-  width: 64,
-  height: 64,
+  width: SYMBOL_SIZE,
+  height: SYMBOL_SIZE,
   borderRadius: '50%',
+  overflow: 'hidden',
 })
 
 const detailBoxStyle = css({
@@ -62,8 +66,12 @@ class DetailHead extends Component {
     const detailFields = details(data, t, locale)
     return (
       <TextCenter>
-        {!!img && <img {...symbolStyle} {...imageStyle} src={img} alt='' />}
-        {!img && !!Icon && <Icon className={symbolStyle} size={64} />}
+        {!!img && (
+          <span {...symbolStyle} {...imageStyle}>
+            <Image width={SYMBOL_SIZE} height={SYMBOL_SIZE} src={img} alt='' />
+          </span>
+        )}
+        {!img && !!Icon && <Icon className={symbolStyle} size={SYMBOL_SIZE} />}
         <h1 {...titleStyle}>{title(data, t, locale)}</h1>
         <p {...metaStyle}>{subtitle(data, t, locale)}</p>
         {detailFields.length > 0 && (

--- a/src/components/DetailHead.js
+++ b/src/components/DetailHead.js
@@ -68,7 +68,13 @@ class DetailHead extends Component {
       <TextCenter>
         {!!img && (
           <span {...symbolStyle} {...imageStyle}>
-            <Image width={SYMBOL_SIZE} height={SYMBOL_SIZE} src={img} alt='' />
+            <Image
+              width={SYMBOL_SIZE}
+              height={SYMBOL_SIZE}
+              src={img}
+              priority
+              alt=''
+            />
           </span>
         )}
         {!img && !!Icon && <Icon className={symbolStyle} size={SYMBOL_SIZE} />}

--- a/src/components/ListView.js
+++ b/src/components/ListView.js
@@ -5,6 +5,7 @@ import { metaRule } from './Styled'
 import { LW_BLUE, GREY_LIGHT, mediaM } from '../theme'
 import { css } from 'glamor'
 import Link from 'next/link'
+import Image from 'next/image'
 import { itemPath } from '../utils/routes'
 import Grid, { GridItem } from './Grid'
 
@@ -21,6 +22,7 @@ const symbolStyle = css({
 })
 const portraitStyle = css({
   borderRadius: '50%',
+  overflow: 'hidden',
 })
 const aStyle = css({
   display: 'block',
@@ -54,7 +56,14 @@ const ListView = ({ locale, items, title, subtitle, maxWidth }) => {
       <Link key={id} href={itemPath(item, locale)} prefetch={false}>
         <a {...aStyle}>
           {!!portrait && (
-            <img {...symbolStyle} {...portraitStyle} src={portrait} alt='' />
+            <span {...symbolStyle} {...portraitStyle}>
+              <Image
+                width={SYMBOL_SIZE}
+                height={SYMBOL_SIZE}
+                src={portrait}
+                alt=''
+              />
+            </span>
           )}
           {!portrait && !!Icon && (
             <Icon className={symbolStyle} size={SYMBOL_SIZE} />


### PR DESCRIPTION
For blog article card and parliamentarian profile pics. Article covers are currently not easily possible because backend does not provide image size ahead of time.

The nice things is that images now only load when in viewport. E.g. parliamentarian page no longer directly loads 250 images. And all magic optimisations happen automatically like WebP and src sets.

Homepage image size goes down from 1.6mb to 254kb. Parliamentarian overview images down from 9.9mb to 82kb initially and 847kb when completely scrolled. All measurements in Chrome with WebP.